### PR TITLE
fix: labels in the struct level

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -54,6 +54,9 @@ func IterateStruct(t reflect.Type, v reflect.Value, prefixMetric string, labels 
 
 		switch field.Type.Kind() {
 		case reflect.Struct:
+			// Reset the labels for each struct
+			labels = []string{}
+
 			if field.Type.String() == "pmbuilder.InstanceInterface" {
 				continue
 			}
@@ -117,12 +120,9 @@ func IterateStruct(t reflect.Type, v reflect.Value, prefixMetric string, labels 
 			//  }
 			// }
 			// labels = []string{"server", "version"}
-			var commonLabels []string
 			if field.Tag.Get("labels") != "" {
-				commonLabels = strings.Split(field.Tag.Get("labels"), ",")
+				labels = append(labels, strings.Split(field.Tag.Get("labels"), ",")...)
 			}
-			// merge the common labels with the labels from the parent struct
-			labels = append(labels, commonLabels...)
 
 			IterateStruct(field.Type, v.Field(i), pm, labels)
 		case reflect.Ptr:


### PR DESCRIPTION
This pull request refactors the `IterateStruct` function in `internal/builder/builder.go` to improve label handling by resetting and simplifying label management. The most important changes focus on ensuring labels are reset for each struct and streamlining how labels are appended.

### Label Handling Improvements:

* Reset the `labels` slice at the start of processing each struct to avoid unintended label carryover between different structs. (`[internal/builder/builder.goR57-R59](diffhunk://#diff-38470f4364cc41382de32fdc999bfa165543c15ae246c08ff4a805405bdd5ee5R57-R59)`)
* Simplified label management by directly appending labels from the `field.Tag` to the existing `labels` slice, removing the intermediate `commonLabels` variable and redundant merging logic. (`[internal/builder/builder.goL120-L125](diffhunk://#diff-38470f4364cc41382de32fdc999bfa165543c15ae246c08ff4a805405bdd5ee5L120-L125)`)